### PR TITLE
Fix for not mapped function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,17 @@ import "fmt"
 import "gopkg.in/masci/flickr.v2"
 
 client := flickr.NewFlickrClient("your_apikey", "your_apisecret")
+client.Init()
 client.Args.Set("method", "flickr.cameras.getBrandModels")
 client.Args.Set("brand", "nikon")
 
+client.OAuthSign()
 response := &flickr.BasicResponse{}
-    err := flickr.DoGet(client, response)
-if err == nil {
+err := flickr.DoGet(client, response)
+
+if err != nil {
+    fmt.Printf("Error: %s", err)
+} else {
     fmt.Println("Api response:", response.Extra)
 }
 ```


### PR DESCRIPTION
The example from "Api coverage" in "README.md" doesn't work for me.
There is need to call `client.Init()` and `client.OAuthSign()` to make it work
